### PR TITLE
Fix null dereference in an error condition

### DIFF
--- a/lib/src/db/model_db_impl.dart
+++ b/lib/src/db/model_db_impl.dart
@@ -135,7 +135,7 @@ class ModelDBImpl implements ModelDB {
   ///
   /// If the model class `type` is not found it will throw an `ArgumentError`.
   String kindName(Type type) {
-    var kind = _modelDesc2Type[type].kind;
+    var kind = _modelDesc2Type[type]?.kind;
     if (kind == null) {
       throw new ArgumentError(
           'The class $type was not associated with a kind.');


### PR DESCRIPTION
If the type was not found in the description table, we dereferenced a null instead of throwing the nicer ArgumentError.  This fixes that.