### PR TITLE
Test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ of the Google Cloud project to use. The value of the environment variable
 `GCLOUD_E2E_TEST_KEY` is a Google Cloud Storage path (starting with `gs://`)
 to a JSON key file for a service account providing access to the Cloud Project.
 
-To pass the datastore tests you will also need to create indexes as follows:
+You will also need to create indexes as follows:
 
 ```bash
 gcloud --project "$GCLOUD_E2E_TEST_PROJECT" datastore indexes create test/index.yaml

--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ of the Google Cloud project to use. The value of the environment variable
 `GCLOUD_E2E_TEST_KEY` is a Google Cloud Storage path (starting with `gs://`)
 to a JSON key file for a service account providing access to the Cloud Project.
 
+To pass the datastore tests you will also need to create indexes as follows:
+
+```bash
+gcloud --project "$GCLOUD_E2E_TEST_PROJECT" datastore indexes create test/index.yaml
+```
+
 [Datastore]: https://cloud.google.com/datastore/
 [GCS]: https://cloud.google.com/storage/
 [PubSub]: https://cloud.google.com/pubsub/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   googleapis_auth: '>=0.2.3 <0.3.0'
   http_parser: '>=2.0.0 <4.0.0'
   mime: '>=0.9.0+3 <0.10.0'
-  test: '>=0.12.0 <0.13.0'
+  test: ^1.5.1
 transformers:
 - $dart2js:
     $include: []

--- a/test/index.yaml
+++ b/test/index.yaml
@@ -1,0 +1,47 @@
+# To run tests for datastore, the following index.yaml must be declared for
+# the project using:
+#         $ gcloud datastore indexes create test/index.yaml
+indexes:
+# Needed by tests in: test/db/e2e/db_test_impl.dart
+- kind: User
+  ancestor: no
+  properties:
+  - name: name
+    direction: asc
+  - name: nickname
+    direction: desc
+- kind: User
+  ancestor: no
+  properties:
+  - name: name
+    direction: desc
+  - name: nickname
+    direction: desc
+- kind: User
+  ancestor: no
+  properties:
+  - name: name
+    direction: desc
+  - name: nickname
+    direction: asc
+- kind: User
+  ancestor: no
+  properties:
+  - name: language
+    direction: asc
+  - name: name
+    direction: asc
+# Needed by tests in: test/datastore/e2e/datastore_test_impl.dart
+- kind: TestQueryKind
+  ancestor: no
+  properties:
+  - name: indexedProp
+    direction: asc
+  - name: blobPropertyIndexed
+    direction: asc
+- kind: TestQueryKind
+  ancestor: no
+  properties:
+  - name: listproperty
+  - name: test_property
+    direction: desc

--- a/test/storage/e2e_test.dart
+++ b/test/storage/e2e_test.dart
@@ -71,7 +71,7 @@ void main() {
     });
 
     test('create-with-predefined-acl-delete', () async {
-      for (var e in <PredefinedAcl, int>{
+      final cases = <PredefinedAcl, int>{
         // See documentation:
         // https://cloud.google.com/storage/docs/access-control/lists
         PredefinedAcl.authenticatedRead: 2,
@@ -79,7 +79,8 @@ void main() {
         PredefinedAcl.projectPrivate: 3,
         PredefinedAcl.publicRead: 2,
         PredefinedAcl.publicReadWrite: 2,
-      }.entries) {
+      };
+      for (var e in cases.entries) {
         var predefinedAcl = e.key;
         var expectedLength = e.value;
         var bucketName = generateBucketName();

--- a/test/storage/e2e_test.dart
+++ b/test/storage/e2e_test.dart
@@ -70,32 +70,31 @@ void main() {
       }));
     });
 
-    test('create-with-predefined-acl-delete', () {
-      Future<Acl> test(PredefinedAcl predefinedAcl, expectedLength) {
+    test('create-with-predefined-acl-delete', () async {
+      for (var e in <PredefinedAcl, int>{
+        // See documentation:
+        // https://cloud.google.com/storage/docs/access-control/lists
+        PredefinedAcl.authenticatedRead: 2,
+        PredefinedAcl.private: 1,
+        PredefinedAcl.projectPrivate: 3,
+        PredefinedAcl.publicRead: 2,
+        PredefinedAcl.publicReadWrite: 2,
+      }.entries) {
+        var predefinedAcl = e.key;
+        var expectedLength = e.value;
         var bucketName = generateBucketName();
-        return storage
-            .createBucket(bucketName, predefinedAcl: predefinedAcl)
-            .then(expectAsync1((result) {
-          expect(result, isNull);
-          return storage.bucketInfo(bucketName).then(expectAsync1((info) {
-            var acl = info.acl;
-            expect(info.bucketName, bucketName);
-            expect(acl.entries.length, expectedLength);
-            return storage.deleteBucket(bucketName).then(expectAsync1((result) {
-              expect(result, isNull);
-            }));
-          }));
-        }));
+        // Sleep for 2 seconds to avoid bucket request limit, see:
+        // https://cloud.google.com/storage/quotas#buckets
+        await Future.delayed(Duration(seconds: 2));
+        var r1 = await storage.createBucket(bucketName,
+            predefinedAcl: predefinedAcl);
+        expect(r1, isNull);
+        var info = await storage.bucketInfo(bucketName);
+        expect(info.bucketName, bucketName);
+        expect(info.acl.entries.length, expectedLength);
+        var r2 = await storage.deleteBucket(bucketName);
+        expect(r2, isNull);
       }
-
-      return Future.forEach([
-        // See documentation: https://cloud.google.com/storage/docs/access-control/lists
-        () => test(PredefinedAcl.authenticatedRead, 2),
-        () => test(PredefinedAcl.private, 1),
-        () => test(PredefinedAcl.projectPrivate, 3),
-        () => test(PredefinedAcl.publicRead, 2),
-        () => test(PredefinedAcl.publicReadWrite, 2),
-      ], (f) => f().then(expectAsync1((_) {})));
     });
 
     test('create-error', () {


### PR DESCRIPTION
I still have the following error, which likely has to do with using `db.Model` when calling `commit()`... I'm not entirely sure, these tests looks to be pre-async/await, so if I decide to dive into them I'll probably have to refactor a bit too...

```
01:19 +151 -1: test/db_all_e2e_test.dart: datastore_test e2e_db query [E]
  Invalid argument(s): The class Model was not associated with a kind.
  lib/src/db/model_db_impl.dart 140:7              ModelDBImpl.kindName
  lib/src/db/db.dart 137:32                        new Query
  lib/src/db/db.dart 328:16                        DatastoreDB.query
  test/db/e2e/db_test_impl.dart 659:10             waitUntilEntitiesHelper.waitForKeys
  test/db/e2e/db_test_impl.dart 679:23             waitUntilEntitiesHelper.<fn>
  dart:async                                       Future.forEach
  test/db/e2e/db_test_impl.dart 678:17             waitUntilEntitiesHelper
  test/db/e2e/db_test_impl.dart 642:10             waitUntilEntitiesReady
  test/db/e2e/db_test_impl.dart 454:16             runTests.<fn>.<fn>.<fn>
  dart:async                                       _completeOnAsyncReturn
  package:_discoveryapis_commons/src/clients.dart  ApiRequester.request
  ===== asynchronous gap ===========================
  dart:async                                       Future.forEach
  test/db/e2e/db_test_impl.dart 678:17             waitUntilEntitiesHelper
  test/db/e2e/db_test_impl.dart 642:10             waitUntilEntitiesReady
  test/db/e2e/db_test_impl.dart 454:16             runTests.<fn>.<fn>.<fn>
  dart:async                                       _completeOnAsyncReturn
  package:_discoveryapis_commons/src/clients.dart  ApiRequester.request
  ===== asynchronous gap ===========================
  dart:async                                       Future.forEach
  test/db/e2e/db_test_impl.dart 678:17             waitUntilEntitiesHelper
  test/db/e2e/db_test_impl.dart 642:10             waitUntilEntitiesReady
  test/db/e2e/db_test_impl.dart 454:16             runTests.<fn>.<fn>.<fn>
  dart:async                                       _completeOnAsyncReturn
  package:_discoveryapis_commons/src/clients.dart  ApiRequester.request
  ===== asynchronous gap ===========================
  dart:async                                       Future.then
  test/db/e2e/db_test_impl.dart 453:48             runTests.<fn>.<fn>
```

Anyways, I think this is an improvement, even if it doesn't fix all tests :)