### PR TITLE
Update to pubsub v1 API

### DIFF
--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -9,7 +9,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-import 'package:googleapis_beta/pubsub/v1beta2.dart' as pubsub;
+import 'package:googleapis/pubsub/v1.dart' as pubsub;
 
 import 'common.dart';
 import 'service_scope.dart' as ss;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   _discoveryapis_commons: ^0.1.6+1
   googleapis: '>=0.50.2 <1.0.0'
-  googleapis_beta: '>=0.45.2 <1.0.0'
   http: '>=0.11.0 <0.12.0'
 dev_dependencies:
   googleapis_auth: '>=0.2.3 <0.3.0'

--- a/test/pubsub/pubsub_test.dart
+++ b/test/pubsub/pubsub_test.dart
@@ -10,13 +10,13 @@ import 'package:test/test.dart';
 
 import 'package:gcloud/pubsub.dart';
 
-import 'package:googleapis_beta/pubsub/v1beta2.dart' as pubsub;
+import 'package:googleapis/pubsub/v1.dart' as pubsub;
 
 import '../common.dart';
 import '../common_e2e.dart';
 
 const String HOSTNAME = 'pubsub.googleapis.com';
-const String ROOT_PATH = '/v1beta2/';
+const String ROOT_PATH = '/v1/';
 
 MockClient mockClient() => new MockClient(HOSTNAME, ROOT_PATH);
 


### PR DESCRIPTION
My first goal was to enable pubsub emulator on local machine.
Pubsub emulator requires pubsub v1 API.