### PR TITLE
Support pubsub emulator

### DIFF
--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -9,7 +9,7 @@ import 'dart:collection';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
-import 'package:googleapis_beta/pubsub/v1beta2.dart' as pubsub;
+import 'package:googleapis/pubsub/v1.dart' as pubsub;
 
 import 'common.dart';
 import 'service_scope.dart' as ss;

--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -7,6 +7,7 @@ library gcloud.pubsub;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:io';
 import 'package:http/http.dart' as http;
 
 import 'package:googleapis/pubsub/v1.dart' as pubsub;
@@ -122,7 +123,12 @@ abstract class PubSub {
   ///
   /// Returs an object providing access to Pub/Sub. The passed-in [client] will
   /// not be closed automatically. The caller is responsible for closing it.
-  factory PubSub(http.Client client, String project) = _PubSubImpl;
+  factory PubSub(http.Client client, String project) {
+    var emulator = Platform.environment['PUBSUB_EMULATOR_HOST'];
+    return emulator == null
+        ? new _PubSubImpl(client, project)
+        : new _PubSubImpl.rootUrl(client, project, "http://$emulator/");
+  }
 
   /// The name of the project.
   String get project;

--- a/lib/src/pubsub_impl.dart
+++ b/lib/src/pubsub_impl.dart
@@ -15,6 +15,11 @@ class _PubSubImpl implements PubSub {
         _topicPrefix = 'projects/$project/topics/',
         _subscriptionPrefix = 'projects/$project/subscriptions/';
 
+  _PubSubImpl.rootUrl(http.Client client, this.project, String rootUrl)
+      : _api = new pubsub.PubsubApi(client, rootUrl: rootUrl),
+        _topicPrefix = 'projects/$project/topics/',
+        _subscriptionPrefix = 'projects/$project/subscriptions/';
+
   String _fullTopicName(String name) {
     return name.startsWith('projects/') ? name : '${_topicPrefix}$name';
   }
@@ -24,7 +29,7 @@ class _PubSubImpl implements PubSub {
   }
 
   Future<pubsub.Topic> _createTopic(String name) {
-    return _api.projects.topics.create(new pubsub.Topic()..name = name, name);
+    return _api.projects.topics.create(null, name);
   }
 
   Future _deleteTopic(String name) {
@@ -45,7 +50,6 @@ class _PubSubImpl implements PubSub {
   Future<pubsub.Subscription> _createSubscription(
       String name, String topic, Uri endpoint) {
     var subscription = new pubsub.Subscription()
-      ..name = name
       ..topic = topic;
     if (endpoint != null) {
       var pushConfig = new pubsub.PushConfig()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,6 @@ environment:
 dependencies:
   _discoveryapis_commons: ^0.1.6+1
   googleapis: '>=0.50.2 <1.0.0'
-  googleapis_beta: '>=0.45.2 <1.0.0'
   http: '>=0.11.0 <0.12.0'
 dev_dependencies:
   googleapis_auth: '>=0.2.3 <0.3.0'

--- a/test/pubsub/pubsub_e2e_test.dart
+++ b/test/pubsub/pubsub_e2e_test.dart
@@ -186,6 +186,6 @@ void main() {
 
       await pubsub.deleteSubscription(subscriptionName);
       await pubsub.deleteTopic(topicName);
-    });
+    }, timeout: const Timeout(const Duration(minutes: 2)));
   });
 }

--- a/test/pubsub/pubsub_test.dart
+++ b/test/pubsub/pubsub_test.dart
@@ -50,9 +50,7 @@ main() {
             'PUT',
             'projects/$PROJECT/topics/test-topic',
             expectAsync1((http.Request request) {
-              var requestTopic =
-                  new pubsub.Topic.fromJson(jsonDecode(request.body) as Map);
-              expect(requestTopic.name, absoluteName);
+              expect(request.body, isEmpty);
               return mock.respond(new pubsub.Topic()..name = absoluteName);
             }, count: 2));
 
@@ -429,9 +427,8 @@ main() {
             'PUT',
             'projects/$PROJECT/subscriptions',
             expectAsync1((request) {
-              var requestSubscription = new pubsub.Subscription.fromJson(
-                  jsonDecode(request.body) as Map);
-              expect(requestSubscription.name, absoluteName);
+              var requestSubscription = jsonDecode(request.body) as Map;
+              expect(requestSubscription['topic'], absoluteTopicName);
               return mock
                   .respond(new pubsub.Subscription()..name = absoluteName);
             }, count: 2));

--- a/test/pubsub/pubsub_test.dart
+++ b/test/pubsub/pubsub_test.dart
@@ -10,13 +10,13 @@ import 'package:test/test.dart';
 
 import 'package:gcloud/pubsub.dart';
 
-import 'package:googleapis_beta/pubsub/v1beta2.dart' as pubsub;
+import 'package:googleapis/pubsub/v1.dart' as pubsub;
 
 import '../common.dart';
 import '../common_e2e.dart';
 
 const String HOSTNAME = 'pubsub.googleapis.com';
-const String ROOT_PATH = '/v1beta2/';
+const String ROOT_PATH = '/v1/';
 
 MockClient mockClient() => new MockClient(HOSTNAME, ROOT_PATH);
 


### PR DESCRIPTION
I updated `createTopic|Subscription` methods, because pubsub emulator doesn't work when topic name is present in the payload

Fix #65 