### PR TITLE
Various enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.1
+
+ * Added examples.
+ * Fixed formatting and lints.
+ * Allow `Model` classes to contain constructors with optional or named
+   arguments (as long as they're annotated with `@required`).
+ * Add generics support to `withTransaction()`.
+
 ## 0.6.0+4
 
  * Updated package description.

--- a/lib/db.dart
+++ b/lib/db.dart
@@ -14,6 +14,8 @@ import 'dart:core';
 import 'dart:core' as core;
 import 'dart:mirrors' as mirrors;
 
+import 'package:meta/meta.dart';
+
 import 'common.dart' show StreamFromPages;
 import 'datastore.dart' as ds;
 import 'service_scope.dart' as ss;

--- a/lib/src/db/db.dart
+++ b/lib/src/db/db.dart
@@ -8,7 +8,7 @@ part of gcloud.db;
 ///
 /// The function will be given a [Transaction] object which can be used to make
 /// lookups/queries and queue modifications (inserts/updates/deletes).
-typedef TransactionHandler = Future Function(Transaction transaction);
+typedef TransactionHandler<T> = Future<T> Function(Transaction transaction);
 
 /// A datastore transaction.
 ///
@@ -263,7 +263,7 @@ class DatastoreDB {
   /// A transaction can touch only a limited number of entity groups. This limit
   /// is currently 5.
   // TODO: Add retries and/or auto commit/rollback.
-  Future withTransaction(TransactionHandler transactionHandler) {
+  Future<T> withTransaction<T>(TransactionHandler<T> transactionHandler) {
     return datastore
         .beginTransaction(crossEntityGroup: true)
         .then((datastoreTransaction) {

--- a/lib/src/db/model_db_impl.dart
+++ b/lib/src/db/model_db_impl.dart
@@ -238,15 +238,38 @@ class ModelDBImpl implements ModelDB {
     }
   }
 
+  static bool _isRequiredAnnotation(mirrors.InstanceMirror annotation) {
+    return annotation.type.simpleName == #Required;
+  }
+
   /// Returns true if a  constructor invocation is valid even if the specified
   /// [parameter] is omitted.
   ///
   /// This is  true for named parameters, optional parameters, and parameters
   /// with a default value.
   static bool _canBeOmitted(mirrors.ParameterMirror parameter) {
+    if (parameter.metadata.any(_isRequiredAnnotation)) {
+      return false;
+    }
     return parameter.isOptional ||
         parameter.isNamed ||
         parameter.hasDefaultValue;
+  }
+
+  /// Returns true if the specified [classMirror] has a default (unnamed)
+  /// constructor that accepts an empty arguments list.
+  @visibleForTesting
+  static bool hasDefaultConstructor(mirrors.ClassMirror classMirror) {
+    for (var declaration in classMirror.declarations.values) {
+      if (declaration is mirrors.MethodMirror) {
+        if (declaration.isConstructor &&
+            declaration.constructorName == const Symbol('') &&
+            declaration.parameters.every(_canBeOmitted)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   void _tryLoadNewModelClassFull(
@@ -267,18 +290,7 @@ class ModelDBImpl implements ModelDB {
         _propertiesFromModelDescription(modelClass);
 
     // Ensure we have an empty constructor.
-    bool defaultConstructorFound = false;
-    for (var declaration in modelClass.declarations.values) {
-      if (declaration is mirrors.MethodMirror) {
-        if (declaration.isConstructor &&
-            declaration.constructorName == const Symbol('') &&
-            declaration.parameters.every(_canBeOmitted)) {
-          defaultConstructorFound = true;
-          break;
-        }
-      }
-    }
-    if (!defaultConstructorFound) {
+    if (!hasDefaultConstructor(modelClass)) {
       throw StateError('Class ${modelClass.simpleName} does not have a default '
           'constructor.');
     }
@@ -452,7 +464,7 @@ class _ModelDescription<T extends Model> {
 
     try {
       mirror.setField(mirrors.MirrorSystem.getSymbol(fieldName), value);
-    } catch (error) {
+    } on TypeError catch (error) {
       throw StateError('Error trying to set property "${prop.propertyName}" '
           'to $value for field "$fieldName": $error');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.6.1-dev
+version: 0.6.1
 author: Dart Team <misc@dartlang.org>
 description: |
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   _discoveryapis_commons: ^0.1.6+1
   googleapis: '>=0.50.2 <1.0.0'
   http: '>=0.11.0 <0.13.0'
+  meta: ^1.0.2
 
 dev_dependencies:
   googleapis_auth: '>=0.2.3 <0.3.0'

--- a/test/db/db_test.dart
+++ b/test/db/db_test.dart
@@ -4,7 +4,10 @@
 
 library gcloud.db_test;
 
+import 'dart:mirrors' show reflectClass;
+
 import 'package:gcloud/db.dart';
+import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 
 @Kind()
@@ -46,5 +49,52 @@ main() {
       expect(key.id, 42);
       expect(key.type, equals(Foobar));
     });
+
+    test('hasDefaultConstructor', () {
+      expect(hasDefaultConstructor(Empty), isTrue);
+      expect(hasDefaultConstructor(OnlyNamedConstructor), isFalse);
+      expect(hasDefaultConstructor(DefaultAndNamedConstructor), isTrue);
+      expect(hasDefaultConstructor(RequiredArguments), isFalse);
+      expect(hasDefaultConstructor(OnlyPositionalArguments), isTrue);
+      expect(hasDefaultConstructor(OnlyNamedArguments), isTrue);
+      expect(hasDefaultConstructor(RequiredNamedArguments), isFalse);
+      expect(hasDefaultConstructor(DefaultArgumentValues), isTrue);
+    });
   });
+}
+
+bool hasDefaultConstructor(Type type) =>
+    ModelDBImpl.hasDefaultConstructor(reflectClass(type));
+
+class Empty {
+  const Empty();
+}
+
+class OnlyNamedConstructor {
+  const OnlyNamedConstructor.named();
+}
+
+class DefaultAndNamedConstructor {
+  const DefaultAndNamedConstructor();
+  const DefaultAndNamedConstructor.named();
+}
+
+class RequiredArguments {
+  const RequiredArguments(int arg);
+}
+
+class OnlyPositionalArguments {
+  const OnlyPositionalArguments([int arg, int arg2]);
+}
+
+class OnlyNamedArguments {
+  const OnlyNamedArguments({int arg, int arg2});
+}
+
+class RequiredNamedArguments {
+  const RequiredNamedArguments({int arg1, @required int arg2});
+}
+
+class DefaultArgumentValues {
+  const DefaultArgumentValues([int arg1 = 1, int arg2 = 2]);
 }


### PR DESCRIPTION
* Provide a more helpful (contextual) exception message when
  we fail to set a field while decoding a property.

* Relax the constraints that dictate whether we found a
  "default constructor" when loading a model class. The
  existing constraints didn't allow a class to be used both
  as a model and as a json_serializable target, since the
  latter requires the default constructor to provide named
  arguments for all the properties.

* Add generics support to `withTransaction()`, making the signature:
  `Future<T> withTransaction<T>(TransactionHandler<T>)`.
  This enables type safety in the returned future vis-a-vis
  the return type of the transaction callback.