### PR TITLE
Fix logic in `Transaction.rollback()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+ * Fixed bug in `Transaction.rollback()`.
+
 ## 0.6.1
 
  * Added examples.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.6.1
+version: 0.6.2
 author: Dart Team <misc@dartlang.org>
 description: |
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.


### PR DESCRIPTION
It's common to have code that looks like the following:

```dart
try {
  ...
  transaction.commit();
} catch (error) {
  transaction.rollback();
}
```

This code is prone to errors - if the commit fails (and
throws an exception), then the attempt to call `rollback()`
will throw a secondary error (transaciton has already been
committed),  thus masking the real error.

This PR fixes that logic.