### PR TITLE
Add `DatastoreDB.lookupValue()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+ * Added `DatastoreDB.lookupValue()`
+
 ## 0.6.2
 
  * Fixed bug in `Transaction.rollback()`.

--- a/lib/db.dart
+++ b/lib/db.dart
@@ -22,6 +22,7 @@ import 'service_scope.dart' as ss;
 
 part 'src/db/annotations.dart';
 part 'src/db/db.dart';
+part 'src/db/exceptions.dart';
 part 'src/db/models.dart';
 part 'src/db/model_db.dart';
 part 'src/db/model_db_impl.dart';

--- a/lib/src/db/db.dart
+++ b/lib/src/db/db.dart
@@ -302,10 +302,41 @@ class DatastoreDB {
 
   /// Looks up [keys] in the datastore and returns a list of [Model] objects.
   ///
+  /// Any key that is not found in the datastore will have a corresponding
+  /// value of null in the list of model objects that is returned.
+  ///
   /// For transactions, please use [beginTransaction] and call the [lookup]
   /// method on it's returned [Transaction] object.
+  ///
+  /// See also:
+  ///
+  ///  * [lookupValue], which looks a single value up by its key, requiring a
+  ///    successful lookup.
   Future<List<T>> lookup<T extends Model>(List<Key> keys) {
     return _lookupHelper<T>(this, keys);
+  }
+
+  /// Looks up a single [key] in the datastore, and returns the associated
+  /// [Model] object.
+  ///
+  /// If [orElse] is specified, then it will be consulted to provide a default
+  /// value for the model object in the event that [key] was not found in the
+  /// datastore.
+  ///
+  /// If the [key] is not found in the datastore and [orElse] was not
+  /// specified, then an [ArgumentError] will be thrown.
+  Future<T> lookupValue<T extends Model>(Key key, {T orElse()}) async {
+    final List<T> values = await lookup(<Key>[key]);
+    assert(values.length == 1);
+    T value = values.single;
+    if (value == null) {
+      if (orElse != null) {
+        value = orElse();
+      } else {
+        throw ArgumentError('No value associated with key: $key');
+      }
+    }
+    return value;
   }
 
   /// Add [inserts] to the datastore and remove [deletes] from it.

--- a/lib/src/db/exceptions.dart
+++ b/lib/src/db/exceptions.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+part of gcloud.db;
+
+/// Exception that gets thrown when a caller attempts to look up a value by
+/// its key, and the key cannot be found in the datastore.
+class KeyNotFoundException implements Exception {
+  /// Creates a new [KeyNotFoundException] for the specified [key].
+  const KeyNotFoundException(this.key);
+
+  /// The [Key] that was not found in the datastore.
+  final Key key;
+
+  @override
+  String toString() => 'Key not found: ${key.type}:${key.id}';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.6.2
+version: 0.6.3
 author: Dart Team <misc@dartlang.org>
 description: |
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.


### PR DESCRIPTION
`DatastoreDB.lookup()` returns null rows in its
results, which is confusing - the caller calls `lookup(keys)`,
none of which are successfully looked up, and instead of getting
an empty list back, they get a list of nulls.

Since changing that behavior would be an API breaking
change, and since a very common use-case is calling
`lookup(<Key>[key])`, this change adds a new API method for
looking up a single key. This new method will throw if the
lookup was unsuccessful.