### PR TITLE
Add ability to change Datastore Root URL and document emulator usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ for this additional API level is to bridge the gap between the different APIs
 exposed inside App Engine and through the public REST API. We reserve the
 rights to modify and maybe even remove this additional layer at any time.
 
+### Using the Datastore emulator
+
+The gcloud sdk provides an easy-to-use datastore emulator. The emulator can be launched via
+
+```console
+$ gcloud beta emulators datastore start
+```
+
+To use the Datastore emulator, you must pass the host and address at which the 
+emulator is running to the ApiClient. You can use an empty API key for the client
+authentication details.
+
+```dart
+  final client = auth.clientViaApiKey("");
+  final db = DatastoreDB(
+    datastore_impl.DatastoreImpl(
+      client,
+      project,
+      rootUrl: "http://localhost:8080/",
+    ),
+  );
+```
+
 ## Cloud Storage
 Google Cloud Storage provide a highly available object store (aka BLOB
 store). See the product page [https://cloud.google.com/storage/][GCS]

--- a/lib/src/datastore_impl.dart
+++ b/lib/src/datastore_impl.dart
@@ -28,8 +28,15 @@ class DatastoreImpl implements datastore.Datastore {
 
   /// The [project] parameter is the name of the cloud project (it should not
   /// start with a `s~`).
-  DatastoreImpl(http.Client client, String project)
-      : _api = api.DatastoreApi(client),
+  /// The [rootURL] and [servicePath] parameters may be used to specify an
+  /// alternate datastore host location and path; this is particularly useful
+  /// for the datastore emulator.
+  DatastoreImpl(http.Client client, String project,
+      {String rootUrl, String servicePath = ''})
+      : _api = rootUrl != null
+            ? api.DatastoreApi(client,
+                rootUrl: rootUrl, servicePath: servicePath)
+            : api.DatastoreApi(client, servicePath: servicePath),
         _project = project;
 
   api.Key _convertDatastore2ApiKey(datastore.Key key, {bool enforceId = true}) {


### PR DESCRIPTION
This allows specifying the datastore root url, primarily to make it possible to use the datastore emulator in a non-appengine context and with the higher-level interface specified in this package.

This resolves issue #48.