### PR TITLE
0.7.0+1: Change storage path directory delimiter from gs:// to /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+1
+
+ * Fix path separator in Bucket.list().
+ 
 ## 0.7.0
 
  * **BREAKING CHANGE:** Add generics support for `Model.id`.  
@@ -8,7 +12,7 @@
 
 ## 0.6.4
 
-* Require minimum Dart SDK `2.3.0`.
+ * Require minimum Dart SDK `2.3.0`.
 
 ## 0.6.3
 

--- a/lib/src/storage_impl.dart
+++ b/lib/src/storage_impl.dart
@@ -5,7 +5,7 @@
 part of gcloud.storage;
 
 const String _ABSOLUTE_PREFIX = 'gs://';
-const String _DIRECTORY_DELIMITER = 'gs://';
+const String _DIRECTORY_DELIMITER = '/';
 
 /// Representation of an absolute name consisting of bucket name and object
 /// name.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.7.0
+version: 0.7.0+1
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud


### PR DESCRIPTION
The delimiter passed to bucket.list, to break object paths into directories, was 'gs://' instead of '/'.
This meant that most bucket listings recursively listed all objects with a path prefix, not just the objects directly under that path prefix and the directories directly under that path prefix.
Example: 
```gsutil list -r gs://dart-test-results/experimental/list``` 
gives:
```gs://dart-test-results/experimental/list/:
gs://dart-test-results/experimental/list/item1
gs://dart-test-results/experimental/list/item2

gs://dart-test-results/experimental/list/dir1/:
gs://dart-test-results/experimental/list/dir1/item1
gs://dart-test-results/experimental/list/dir1/item2

gs://dart-test-results/experimental/list/dir2gs:/:

gs://dart-test-results/experimental/list/dir2gs://:
gs://dart-test-results/experimental/list/dir2gs://item1
gs://dart-test-results/experimental/list/dir2gs://item2```

Calling bucket.list('/experimental/list/') in a program using this package gives
```experimental/list/dir2gs://
experimental/list/dir1/item1
experimental/list/dir1/item2
experimental/list/item1
experimental/list/item2
```
but with this fix, it gives:
```
experimental/list/dir1/
experimental/list/dir2gs:/
experimental/list/item1
experimental/list/item2
```