### PR TITLE
Upgrade _discoveryapis_commons, and fix mocks to work with newer goog…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0+2
+ 
+ * Upgrade dependency on `_discoveryapis_commons`, changing `ApiRequestError`
+   from an `Error` to an `Exception`. Version constraints on
+   `_discoveryapis_commons` allows both new and old versions.
+
 ## 0.7.0+1
 
  * Fix path separator in Bucket.list().

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.7.0+1
+version: 0.7.0+2
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  _discoveryapis_commons: ^0.1.6+1
+  _discoveryapis_commons: '>=0.1.6+1 <0.3.0'
   googleapis: '>=0.50.2 <1.0.0'
   http: '>=0.11.0 <0.13.0'
   meta: ^1.0.2

--- a/test/common.dart
+++ b/test/common.dart
@@ -20,6 +20,7 @@ class MockClient extends http.BaseClient {
 
   final _bytesHeaderRegexp = RegExp(r'bytes=(\d+)-(\d+)');
 
+  final String hostname;
   final String rootPath;
   final Uri rootUri;
 
@@ -27,7 +28,8 @@ class MockClient extends http.BaseClient {
   http_testing.MockClient client;
 
   MockClient(String hostname, String rootPath)
-      : rootPath = rootPath,
+      : hostname = hostname,
+        rootPath = rootPath,
         rootUri = Uri.parse('https://$hostname$rootPath') {
     client = http_testing.MockClient(handler);
   }
@@ -98,7 +100,7 @@ class MockClient extends http.BaseClient {
 
   Future<http.Response> respondInitiateResumableUpload(project) {
     final headers = Map<String, String>.from(RESPONSE_HEADERS);
-    headers['location'] = 'https://www.googleapis.com/resumable/upload$rootPath'
+    headers['location'] = 'https://$hostname/resumable/upload$rootPath'
         'b/$project/o?uploadType=resumable&alt=json&'
         'upload_id=AEnB2UqucpaWy7d5cr5iVQzmbQcQlLDIKiClrm0SAX3rJ7UN'
         'Mu5bEoC9b4teJcJUKpqceCUeqKzuoP_jz2ps_dV0P0nT8OTuZQ';

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -17,7 +17,7 @@ import 'package:googleapis/storage/v1.dart' as storage;
 import '../common.dart';
 import '../common_e2e.dart';
 
-const String HOSTNAME = 'www.googleapis.com';
+const String HOSTNAME = 'storage.googleapis.com';
 const String ROOT_PATH = '/storage/v1/';
 
 MockClient mockClient() => MockClient(HOSTNAME, ROOT_PATH);


### PR DESCRIPTION
…leapis package

Kind of hope this still works, I'm no longer have credentials required for testing, still waiting for a new setup to be created, lol
(In any case I didn't change anything that should affect production code).