### PR TITLE
Require latest dependencies, start migration

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -62,7 +62,7 @@ jobs:
 
   # Run tests on a matrix consisting of two dimensions:
   # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
-  # 2. release: 2.3.0
+  # 2. release: 2.12.0
   test-legacy-sdk:
     needs: analyze
     runs-on: ${{ matrix.os }}
@@ -71,7 +71,7 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.3.0]
+        sdk: [2.12.0]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.0-dev
+
+ * Require Dart 2.12 or later
+ * Partial migration to null safety:
+   * `package:gcloud/common.dart`
+   * `package:gcloud/http.dart`
+   * `package:gcloud/service_scope.dart`
+
 ## 0.7.3
  * Fixed issue in reflection code affecting `Model<int>` and `Model<String>`,
    but not `Model<dynamic>`.

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 import 'dart:async' show Future;
 import 'dart:convert' show utf8;

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -35,8 +35,8 @@ class StreamFromPages<T> {
   bool _pendingRequest = false;
   bool _paused = false;
   bool _cancelled = false;
-  Page<T> _currentPage;
-  StreamController<T> _controller;
+  late Page<T> _currentPage;
+  late final StreamController<T> _controller;
 
   StreamFromPages(this._firstPageProvider) {
     _controller = StreamController<T>(
@@ -49,7 +49,7 @@ class StreamFromPages<T> {
 
   Stream<T> get stream => _controller.stream;
 
-  void _handleError(e, StackTrace s) {
+  void _handleError(Object e, StackTrace s) {
     _controller.addError(e, s);
     _controller.close();
   }

--- a/lib/datastore.dart
+++ b/lib/datastore.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 /// This library provides a low-level API for accessing Google's Cloud
 /// Datastore.

--- a/lib/db.dart
+++ b/lib/db.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db;
 

--- a/lib/db/metamodel.dart
+++ b/lib/db/metamodel.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.meta_model;
 

--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.pubsub;
 
@@ -112,7 +113,7 @@ void registerPubSubService(PubSub pubsub) {
 ///
 abstract class PubSub {
   /// List of required OAuth2 scopes for Pub/Sub operation.
-  static const SCOPES = [pubsub.PubsubApi.PubsubScope];
+  static const SCOPES = [pubsub.PubsubApi.pubsubScope];
 
   /// Access Pub/Sub using an authenticated client.
   ///

--- a/lib/service_scope.dart
+++ b/lib/service_scope.dart
@@ -86,8 +86,8 @@ const Symbol _ServiceScopeKey = #gcloud.service_scope;
 final _ServiceScope _emptyServiceScope = _ServiceScope();
 
 /// Returns the current [_ServiceScope] object.
-_ServiceScope get _serviceScope =>
-    Zone.current[_ServiceScopeKey] as _ServiceScope;
+_ServiceScope? get _serviceScope =>
+    Zone.current[_ServiceScopeKey] as _ServiceScope?;
 
 /// Start a new zone with a new service scope and run [func] inside it.
 ///
@@ -96,7 +96,7 @@ _ServiceScope get _serviceScope =>
 ///
 /// If an uncaught error occurs and [onError] is given, it will be called. The
 /// `onError` parameter can take the same values as `Zone.current.fork`.
-Future fork(Future Function() func, {Function onError}) {
+Future fork(Future Function() func, {Function? onError}) {
   var currentServiceScope = _serviceScope;
   currentServiceScope ??= _emptyServiceScope;
   return currentServiceScope._fork(func, onError: onError);
@@ -109,7 +109,7 @@ Future fork(Future Function() func, {Function onError}) {
 ///
 /// The registered on-scope-exit functions are executed in reverse registration
 /// order.
-void register(Object key, Object value, {ScopeExitCallback onScopeExit}) {
+void register(Object key, Object value, {ScopeExitCallback? onScopeExit}) {
   var serviceScope = _serviceScope;
   if (serviceScope == null) {
     throw StateError('Not running inside a service scope zone.');
@@ -132,7 +132,7 @@ void registerScopeExitCallback(ScopeExitCallback onScopeExitCallback) {
 /// Look up an item by it's key in the currently active service scope.
 ///
 /// Returns `null` if there is no entry with the given key.
-Object lookup(Object key) {
+Object? lookup(Object key) {
   var serviceScope = _serviceScope;
   if (serviceScope == null) {
     throw StateError('Not running inside a service scope zone.');
@@ -157,7 +157,7 @@ class _ServiceScope {
 
   /// Looks up an object by it's service scope key - returns `null` if not
   /// found.
-  Object lookup(Object serviceScope) {
+  Object? lookup(Object serviceScope) {
     _ensureNotInDestroyingState();
     var entry = _key2Values[serviceScope];
     return entry != null ? entry.value : null;
@@ -167,7 +167,7 @@ class _ServiceScope {
   ///
   /// Optionally calls a [onScopeExit] function once this service scope ends.
   void register(Object serviceScopeKey, Object value,
-      {ScopeExitCallback onScopeExit}) {
+      {ScopeExitCallback? onScopeExit}) {
     _ensureNotInCleaningState();
     _ensureNotInDestroyingState();
 
@@ -191,13 +191,11 @@ class _ServiceScope {
     _ensureNotInCleaningState();
     _ensureNotInDestroyingState();
 
-    if (onScopeExitCallback != null) {
-      _registeredEntries.add(_RegisteredEntry(null, null, onScopeExitCallback));
-    }
+    _registeredEntries.add(_RegisteredEntry(null, null, onScopeExitCallback));
   }
 
   /// Start a new zone with a forked service scope.
-  Future _fork(Future Function() func, {Function onError}) {
+  Future _fork(Future Function() func, {Function? onError}) {
     _ensureNotInCleaningState();
     _ensureNotInDestroyingState();
 
@@ -257,7 +255,7 @@ class _ServiceScope {
         _key2Values.remove(registeredEntry.key);
       }
       if (registeredEntry.scopeExitCallback != null) {
-        return Future.sync(registeredEntry.scopeExitCallback)
+        return Future.sync(registeredEntry.scopeExitCallback!)
             .catchError((e, s) => errors.add(e));
       } else {
         return Future.value();
@@ -274,12 +272,12 @@ class _ServiceScope {
   }
 }
 
-typedef ScopeExitCallback = Future Function();
+typedef ScopeExitCallback = FutureOr Function();
 
 class _RegisteredEntry {
-  final Object key;
-  final Object value;
-  final ScopeExitCallback scopeExitCallback;
+  final Object? key;
+  final Object? value;
+  final ScopeExitCallback? scopeExitCallback;
 
   _RegisteredEntry(this.key, this.value, this.scopeExitCallback);
 }

--- a/lib/service_scope.dart
+++ b/lib/service_scope.dart
@@ -203,10 +203,6 @@ class _ServiceScope {
     var map = {_ServiceScopeKey: serviceScope};
     return runZoned(() {
       var f = func();
-      if (f is! Future) {
-        throw ArgumentError('Forking a service scope zone requires the '
-            'callback function to return a future.');
-      }
       return f.whenComplete(serviceScope._runScopeExitHandlers);
       // ignore: deprecated_member_use
     }, zoneValues: map, onError: onError);

--- a/lib/src/datastore_impl.dart
+++ b/lib/src/datastore_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.datastore_impl;
 
@@ -19,8 +20,8 @@ class TransactionImpl implements datastore.Transaction {
 
 class DatastoreImpl implements datastore.Datastore {
   static const List<String> SCOPES = <String>[
-    api.DatastoreApi.DatastoreScope,
-    api.DatastoreApi.CloudPlatformScope,
+    api.DatastoreApi.datastoreScope,
+    api.DatastoreApi.cloudPlatformScope,
   ];
 
   final api.DatastoreApi _api;
@@ -287,10 +288,9 @@ class DatastoreImpl implements datastore.Datastore {
   @override
   Future<List<datastore.Key>> allocateIds(List<datastore.Key> keys) {
     var request = api.AllocateIdsRequest();
-    request
-      ..keys = keys.map((key) {
-        return _convertDatastore2ApiKey(key, enforceId: false);
-      }).toList();
+    request.keys = keys.map((key) {
+      return _convertDatastore2ApiKey(key, enforceId: false);
+    }).toList();
     return _api.projects.allocateIds(request, _project).then((response) {
       return response.keys.map(_convertApi2DatastoreKey).toList();
     }, onError: _handleError);

--- a/lib/src/db/annotations.dart
+++ b/lib/src/db/annotations.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/db/db.dart
+++ b/lib/src/db/db.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/db/exceptions.dart
+++ b/lib/src/db/exceptions.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/db/model_db.dart
+++ b/lib/src/db/model_db.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/db/model_db_impl.dart
+++ b/lib/src/db/model_db_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/db/models.dart
+++ b/lib/src/db/models.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.db;
 

--- a/lib/src/pubsub_impl.dart
+++ b/lib/src/pubsub_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.pubsub;
 

--- a/lib/src/pubsub_impl.dart
+++ b/lib/src/pubsub_impl.dart
@@ -31,7 +31,7 @@ class _PubSubImpl implements PubSub {
   }
 
   Future<pubsub.Topic> _createTopic(String name) {
-    return _api.projects.topics.create(null, name);
+    return _api.projects.topics.create(pubsub.Topic(), name);
   }
 
   Future _deleteTopic(String name) {

--- a/lib/src/storage_impl.dart
+++ b/lib/src/storage_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 part of gcloud.storage;
 
@@ -220,7 +221,7 @@ class _BucketImpl implements Bucket {
       throw ArgumentError('length must have a value if offset is non-zero.');
     }
 
-    var options = storage_api.DownloadOptions.FullMedia;
+    var options = storage_api.DownloadOptions.fullMedia;
 
     if (length != null) {
       if (length <= 0) {
@@ -637,7 +638,7 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
             name: _objectName,
             predefinedAcl: _predefinedAcl,
             uploadMedia: media,
-            uploadOptions: storage_api.UploadOptions.Default)
+            uploadOptions: storage_api.UploadOptions.defaultOptions)
         .then((response) {
       _doneCompleter.complete(_ObjectInfoImpl(response));
     }, onError: _completeError);
@@ -651,7 +652,7 @@ class _MediaUploadStreamSink implements StreamSink<List<int>> {
             name: _objectName,
             predefinedAcl: _predefinedAcl,
             uploadMedia: media,
-            uploadOptions: storage_api.UploadOptions.Resumable)
+            uploadOptions: storage_api.UploadOptions.resumable)
         .then((response) {
       _doneCompleter.complete(_ObjectInfoImpl(response));
     }, onError: _completeError);

--- a/lib/src/storage_impl.dart
+++ b/lib/src/storage_impl.dart
@@ -107,8 +107,8 @@ class _StorageImpl implements Storage {
     var srcName = _AbsoluteName.parse(src);
     var destName = _AbsoluteName.parse(dest);
     return _api.objects
-        .copy(null, srcName.bucketName, srcName.objectName, destName.bucketName,
-            destName.objectName)
+        .copy(storage_api.Object(), srcName.bucketName, srcName.objectName,
+            destName.bucketName, destName.objectName)
         .then((_) => null);
   }
 

--- a/lib/storage.dart
+++ b/lib/storage.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 /// This library provides access to Google Cloud Storage.
 ///
@@ -505,7 +506,7 @@ abstract class BucketInfo {
 abstract class Storage {
   /// List of required OAuth2 scopes for Cloud Storage operation.
   static const List<String> SCOPES = <String>[
-    storage_api.StorageApi.DevstorageFullControlScope
+    storage_api.StorageApi.devstorageFullControlScope
   ];
 
   /// Initializes access to cloud storage.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: gcloud
-version: 0.7.3
+version: 0.8.0-dev
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  _discoveryapis_commons: '>=0.1.6+1 <0.3.0'
-  googleapis: '>=0.50.2 <1.0.0'
-  http: '>=0.11.0 <0.13.0'
-  meta: ^1.0.2
+  _discoveryapis_commons: ^1.0.0
+  googleapis: ^2.0.0
+  http: '^0.13.0'
+  meta: ^1.3.0
 
 dev_dependencies:
-  googleapis_auth: '>=0.2.3 <0.3.0'
-  http_parser: '>=2.0.0 <4.0.0'
-  mime: '>=0.9.0+3 <0.10.0'
-  pedantic: ^1.4.0
-  test: ^1.5.1
+  googleapis_auth: ^1.1.0
+  http_parser: ^4.0.0
+  mime: ^1.0.0
+  pedantic: ^1.11.0
+  test: ^1.16.0

--- a/test/common.dart
+++ b/test/common.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:convert';

--- a/test/common_e2e.dart
+++ b/test/common_e2e.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.test.common_e2e;
 

--- a/test/datastore/e2e/datastore_test_impl.dart
+++ b/test/datastore/e2e/datastore_test_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library datastore_test;
 

--- a/test/datastore/e2e/utils.dart
+++ b/test/datastore/e2e/utils.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library raw_datastore_test_utils;
 

--- a/test/datastore/error_matchers.dart
+++ b/test/datastore/error_matchers.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library error_matchers;
 

--- a/test/db/db_test.dart
+++ b/test/db/db_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db_test;
 

--- a/test/db/e2e/db_test_impl.dart
+++ b/test/db/e2e/db_test_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library db_test;
 

--- a/test/db/e2e/metamodel_test_impl.dart
+++ b/test/db/e2e/metamodel_test_impl.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library metamodel_test;
 

--- a/test/db/model_db_test.dart
+++ b/test/db/model_db_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db_impl_test;
 

--- a/test/db/model_dbs/duplicate_fieldname.dart
+++ b/test/db/model_dbs/duplicate_fieldname.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.model_test.duplicate_fieldname;
 

--- a/test/db/model_dbs/duplicate_kind.dart
+++ b/test/db/model_dbs/duplicate_kind.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.model_test.duplicate_kind;
 

--- a/test/db/model_dbs/duplicate_property.dart
+++ b/test/db/model_dbs/duplicate_property.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.model_test.duplicate_property;
 

--- a/test/db/model_dbs/multiple_annotations.dart
+++ b/test/db/model_dbs/multiple_annotations.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.model_test.multiple_annotations;
 

--- a/test/db/model_dbs/no_default_constructor.dart
+++ b/test/db/model_dbs/no_default_constructor.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.model_test.no_default_constructor;
 

--- a/test/db/properties_test.dart
+++ b/test/db/properties_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.db.properties_test;
 

--- a/test/db_all_e2e_test.dart
+++ b/test/db_all_e2e_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 @Tags(['e2e'])
 @Timeout(Duration(seconds: 120))

--- a/test/pubsub/pubsub_e2e_test.dart
+++ b/test/pubsub/pubsub_e2e_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 @Tags(['e2e'])
 @Timeout(Duration(seconds: 120))

--- a/test/pubsub/pubsub_test.dart
+++ b/test/pubsub/pubsub_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 import 'dart:async';
 import 'dart:convert';
@@ -255,9 +256,11 @@ void main() {
             registerQueryMock(mock, 70, 50, 1);
 
             var api = PubSub(mock, PROJECT);
-            api.listTopics().listen((_) => throw 'Unexpected',
-                onDone: () => throw 'Unexpected')
-              ..cancel();
+            api
+                .listTopics()
+                .listen((_) => throw 'Unexpected',
+                    onDone: () => throw 'Unexpected')
+                .cancel();
           });
 
           test('cancel', () {
@@ -654,9 +657,11 @@ void main() {
             registerQueryMock(mock, 70, 50, totalCalls: 1);
 
             var api = PubSub(mock, PROJECT);
-            api.listSubscriptions().listen((_) => throw 'Unexpected',
-                onDone: () => throw 'Unexpected')
-              ..cancel();
+            api
+                .listSubscriptions()
+                .listen((_) => throw 'Unexpected',
+                    onDone: () => throw 'Unexpected')
+                .cancel();
           });
 
           test('cancel', () {

--- a/test/pubsub/pubsub_test.dart
+++ b/test/pubsub/pubsub_test.dart
@@ -51,7 +51,7 @@ void main() {
             'PUT',
             'projects/$PROJECT/topics/test-topic',
             expectAsync1((http.Request request) {
-              expect(request.body, isEmpty);
+              expect(request.body, '{}');
               return mock.respond(pubsub.Topic()..name = absoluteName);
             }, count: 2));
 

--- a/test/service_scope_test.dart
+++ b/test/service_scope_test.dart
@@ -39,12 +39,6 @@ void main() {
     }));
   });
 
-  test('fork-callback-returns-non-future', () {
-    // The closure passed to fork() must return a future.
-    expect(() => ss.fork(expectAsync0(() => Future.value())),
-        throwsA(isArgumentError));
-  });
-
   test('error-on-double-insert', () {
     // Ensure that inserting twice with the same key results in an error.
     return ss.fork(expectAsync0(() => Future.sync(() {

--- a/test/service_scope_test.dart
+++ b/test/service_scope_test.dart
@@ -41,7 +41,8 @@ void main() {
 
   test('fork-callback-returns-non-future', () {
     // The closure passed to fork() must return a future.
-    expect(() => ss.fork(expectAsync0(() => null)), throwsA(isArgumentError));
+    expect(() => ss.fork(expectAsync0(() => Future.value())),
+        throwsA(isArgumentError));
   });
 
   test('error-on-double-insert', () {
@@ -209,8 +210,8 @@ void main() {
       }));
       expect(ss.lookup(rootKey), equals('root'));
 
-      Future spawnChild(
-          ownSubKey, otherSubKey, int i, ss.ScopeExitCallback cleanup) {
+      Future spawnChild(Object ownSubKey, Object otherSubKey, int i,
+          ss.ScopeExitCallback cleanup) {
         return ss.fork(expectAsync0(() => Future.sync(() {
               ss.register(subKey, 'fork$i');
               ss.registerScopeExitCallback(cleanup);

--- a/test/storage/e2e_test.dart
+++ b/test/storage/e2e_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 @Tags(['e2e'])
 

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+// @dart=2.9
 
 library gcloud.storage;
 
@@ -270,9 +271,11 @@ void main() {
 
       test('immediate-cancel', () {
         withMockClient((mock, api) {
-          api.listBucketNames().listen((_) => throw 'Unexpected',
-              onDone: () => throw 'Unexpected')
-            ..cancel();
+          api
+              .listBucketNames()
+              .listen((_) => throw 'Unexpected',
+                  onDone: () => throw 'Unexpected')
+              .cancel();
         });
       });
 
@@ -1067,9 +1070,11 @@ void main() {
       test('immediate-cancel', () {
         withMockClient((mock, api) {
           var bucket = api.bucket(bucketName);
-          bucket.list().listen((_) => throw 'Unexpected',
-              onDone: () => throw 'Unexpected')
-            ..cancel();
+          bucket
+              .list()
+              .listen((_) => throw 'Unexpected',
+                  onDone: () => throw 'Unexpected')
+              .cancel();
         });
       });
 


### PR DESCRIPTION
- Upgrade to the latest null safe dependencies
- Fix latest pedantic lints
- Migrate the simple libraries (common, http, service_scope) to null safety
- Add `@dart=2.9` comment to all other libraries

I'm willing to migrate the storage apis in a follow-up PR (or here if that's preferred), but I don't have enough time or interest to take care of the rest.