### PR TITLE
Support latest googleapis, prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.8.0-dev
+## 0.8.0-dev.0
 
  * Require Dart 2.12 or later
  * Partial migration to null safety:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.0-dev
+version: 0.8.0-dev.0
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud
@@ -9,8 +9,8 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: ^2.0.0
-  http: '^0.13.0'
+  googleapis: ^3.0.0
+  http: ^0.13.0
   meta: ^1.3.0
 
 dev_dependencies:
@@ -18,4 +18,4 @@ dev_dependencies:
   http_parser: ^4.0.0
   mime: ^1.0.0
   pedantic: ^1.11.0
-  test: ^1.16.0
+  test: ^1.17.5


### PR DESCRIPTION
Upgrade `googleapis` to `^3.0.0` to support the latest version. I've also changed the version to `0.8.0-dev.0` so that this could be published if we decide to publish before all dependencies are migrated.