### PR TITLE
Support googleapis v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.3
+
+- Support the latest version of the `googleapis` package.
+
 ## 0.8.2
 
  * **BREAKING CHANGE:** `Page.next()` throws if `Page.isLast`, this change only

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.2
+version: 0.8.3
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: ^3.0.0
+  googleapis: ^4.0.0
   http: ^0.13.0
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: ^4.0.0
+  googleapis: ^5.0.0
   http: ^0.13.0
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: ^5.0.0
+  googleapis: '>=3.0.0 <6.0.0'
   http: ^0.13.0
   meta: ^1.3.0
 


### PR DESCRIPTION
Support the latest version 5 of the `googleapis` package.

Closes #123.