### PR TITLE
Update googleapis package to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4
+
+- Support the latest version 6.0.0 of the `googleapis` package.
+
 ## 0.8.3
 
 - Support the latest version of the `googleapis` package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.3
+version: 0.8.4
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 homepage: https://github.com/dart-lang/gcloud

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: '>=3.0.0 <=6.0.0'
+  googleapis: '>=3.0.0 <7.0.0'
   http: ^0.13.0
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: '>=3.0.0 <6.0.0'
+  googleapis: '>=3.0.0 <=6.0.0'
   http: ^0.13.0
   meta: ^1.3.0
 

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -248,7 +248,7 @@ void main() {
 
         return api.bucketInfo(bucketName).then(expectAsync1((result) {
           expect(result.bucketName, bucketName);
-          expect(result.created, DateTime(2014));
+          expect(result.created, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
         }));
       });
     });
@@ -983,7 +983,7 @@ void main() {
         var bucket = api.bucket(bucketName);
         bucket.info(objectName).then(expectAsync1((stat) {
           expect(stat.name, objectName);
-          expect(stat.updated, DateTime(2014));
+          expect(stat.updated, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
           expect(stat.metadata.contentType, 'mime/type');
         }));
       });

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -248,7 +248,8 @@ void main() {
 
         return api.bucketInfo(bucketName).then(expectAsync1((result) {
           expect(result.bucketName, bucketName);
-          expect(result.created, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
+          expect(result.created,
+              anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
         }));
       });
     });
@@ -983,7 +984,8 @@ void main() {
         var bucket = api.bucket(bucketName);
         bucket.info(objectName).then(expectAsync1((stat) {
           expect(stat.name, objectName);
-          expect(stat.updated, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
+          expect(
+              stat.updated, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
           expect(stat.metadata.contentType, 'mime/type');
         }));
       });

--- a/test/storage/storage_test.dart
+++ b/test/storage/storage_test.dart
@@ -243,13 +243,12 @@ void main() {
           expect(request.body.length, 0);
           return mock.respond(storage.Bucket()
             ..name = bucketName
-            ..timeCreated = DateTime(2014));
+            ..timeCreated = DateTime.utc(2014));
         }));
 
         return api.bucketInfo(bucketName).then(expectAsync1((result) {
           expect(result.bucketName, bucketName);
-          expect(result.created,
-              anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
+          expect(result.created, DateTime.utc(2014));
         }));
       });
     });
@@ -976,7 +975,7 @@ void main() {
           expect(request.url.queryParameters['alt'], 'json');
           return mock.respond(storage.Object()
             ..name = objectName
-            ..updated = DateTime(2014)
+            ..updated = DateTime.utc(2014)
             ..contentType = 'mime/type');
         }));
 
@@ -984,8 +983,7 @@ void main() {
         var bucket = api.bucket(bucketName);
         bucket.info(objectName).then(expectAsync1((stat) {
           expect(stat.name, objectName);
-          expect(
-              stat.updated, anyOf(DateTime(2014), DateTime.utc(2014, 1, 1, 8)));
+          expect(stat.updated, DateTime.utc(2014));
           expect(stat.metadata.contentType, 'mime/type');
         }));
       });


### PR DESCRIPTION
Package `googleapis` released a new version `6.0.0` to fix some null safety issue.

Our app `flutter/cocoon` needs the above version to unblock some cron job APIs (https://github.com/flutter/flutter/issues/90019). However, we are relying on `gcloud` package as well. Currently we are using `^0.8.2`, which depends on `googleapis >=3.0.0 <6.0.0`, causing confict.

This PR points googleapis version to the latest release `6.0.0`.