### PR TITLE
allow latest pkg:http and pkg:googleapis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.9
+
+- Support the latest version 1.0.0 of the `http` package.
+- Support the latest version 12.0.0 of the `googleapis` package.
+
 ## 0.8.8
 
 - Require Dart 2.19

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.8
+version: 0.8.9
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 repository: https://github.com/dart-lang/gcloud

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: '>=3.0.0 <11.0.0'
+  googleapis: '>=3.0.0 <12.0.0'
   http: '>=0.13.5 <2.0.0'
   meta: ^1.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   _discoveryapis_commons: ^1.0.0
   googleapis: '>=3.0.0 <11.0.0'
-  http: ^0.13.0
+  http: '>=0.13.5 <2.0.0'
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
`pkg:gcloud` currently doesn't allow the latest version of `pkg:http` (^1.0.0) (similar to https://github.com/GoogleCloudPlatform/functions-framework-dart/pull/395)

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
