### PR TITLE
Extend version constraint to allow googleapis 12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.12
+- Support the latest version 12.0.0 of the `googleapis` package.
+
 ## 0.8.11
 - After the first `Page` created by `Datastore.withRetry()` retries were not
   happening. This is now fixed, ensuring that `Page.next()` will always retry

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gcloud
-version: 0.8.11
+version: 0.8.12
 description: >-
   High level idiomatic Dart API for Google Cloud Storage, Pub-Sub and Datastore.
 repository: https://github.com/dart-lang/gcloud
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   _discoveryapis_commons: ^1.0.0
-  googleapis: '>=3.0.0 <12.0.0'
+  googleapis: '>=3.0.0 <13.0.0'
   http: '>=0.13.5 <2.0.0'
   meta: ^1.3.0
   retry: ^3.1.1


### PR DESCRIPTION
Fix #178